### PR TITLE
change ingest to pick up average weekly columns instead

### DIFF
--- a/glue_rsi_ingest.py
+++ b/glue_rsi_ingest.py
@@ -213,12 +213,12 @@ def ingest(config, snapshot_location_bucket, snapshot_location_key):
                 output_row[question_name] = response_val
 
                 try:
-                    adj_val = float(response["adjustedresponse"])
+                    adj_val = float(response["averageweeklyadjustedresponse"])
 
                 except Exception:
                     adj_val = None
 
-                output_row["adj_{}_returned".format(question_name)] = adj_val
+                output_row["average_weekly_q".format(question_name)] = adj_val
 
             output_rows.append(output_row)
 
@@ -248,9 +248,9 @@ def ingest(config, snapshot_location_bucket, snapshot_location_key):
             "reference",
             "period",
             "Q20",
-            "adj_Q20_returned",
+            "average_weekly_q20",
             "Q21",
-            "adj_Q21_returned",
+            "average_weekly_q21",
             "referencename",
             "enterprisereference",
             "rusic",
@@ -297,14 +297,14 @@ def enrich(config):
            666 as ref_period_end_date,
            666 as reported_start_date,
            666 as reported_end_date,
-           a.adj_q20_returned,
-           a.adj_q21_returned,
-           0.0 as adj_q22_returned,
-           0.0 as adj_q23_returned,
-           0.0 as adj_q24_returned,
-           0.0 as adj_q25_returned,
-           0.0 as adj_q26_returned,
-           0.0 as adj_q27_returned,
+           a.average_weekly_q20,
+           a.average_weekly_q21,
+           0.0 as average_weekly_q22,
+           0.0 as average_weekly_q23,
+           0.0 as average_weekly_q24,
+           0.0 as average_weekly_q25,
+           0.0 as average_weekly_q26,
+           0.0 as average_weekly_q27,
            666 as start_date,
            666 as end_date,
            CAST(b.a_weight as double) as design_weight,

--- a/glue_rsi_ingest.py
+++ b/glue_rsi_ingest.py
@@ -192,7 +192,7 @@ def ingest(config, snapshot_location_bucket, snapshot_location_key):
 
     print("Ingested rows:", sum(len(val) for val in all_responses.values()))
 
-    questions = set(["20", "21"])
+    questions = {"20", "21", "22", "23", "24", "25", "26", "27"}
     output_rows = []
 
     for ref, responses in all_responses.items():
@@ -251,6 +251,18 @@ def ingest(config, snapshot_location_bucket, snapshot_location_key):
             "average_weekly_q20",
             "Q21",
             "average_weekly_q21",
+            "Q22",
+            "average_weekly_q22",
+            "Q23",
+            "average_weekly_q23",
+            "Q24",
+            "average_weekly_q24",
+            "Q25",
+            "average_weekly_q25",
+            "Q26",
+            "average_weekly_q26",
+            "Q27",
+            "average_weekly_q27",
             "referencename",
             "enterprisereference",
             "rusic",
@@ -299,12 +311,12 @@ def enrich(config):
            666 as reported_end_date,
            a.average_weekly_q20,
            a.average_weekly_q21,
-           0.0 as average_weekly_q22,
-           0.0 as average_weekly_q23,
-           0.0 as average_weekly_q24,
-           0.0 as average_weekly_q25,
-           0.0 as average_weekly_q26,
-           0.0 as average_weekly_q27,
+           a.average_weekly_q22,
+           a.average_weekly_q23,
+           a.average_weekly_q24,
+           a.average_weekly_q25,
+           a.average_weekly_q26,
+           a.average_weekly_q27,
            666 as start_date,
            666 as end_date,
            CAST(b.a_weight as double) as design_weight,

--- a/glue_rsi_ingest.py
+++ b/glue_rsi_ingest.py
@@ -218,7 +218,7 @@ def ingest(config, snapshot_location_bucket, snapshot_location_key):
                 except Exception:
                     adj_val = None
 
-                output_row["average_weekly_q".format(response["questioncode"])] = adj_val
+                output_row[f"average_weekly_q{response['questioncode']}"] = adj_val
 
             output_rows.append(output_row)
 

--- a/glue_rsi_ingest.py
+++ b/glue_rsi_ingest.py
@@ -218,7 +218,7 @@ def ingest(config, snapshot_location_bucket, snapshot_location_key):
                 except Exception:
                     adj_val = None
 
-                output_row["average_weekly_q".format(question_name)] = adj_val
+                output_row["average_weekly_q".format(response["questioncode"])] = adj_val
 
             output_rows.append(output_row)
 


### PR DESCRIPTION
Made sure that the averageweeklyadjustedresponse gets picked up instead of adjustedresponse. The new column name should match the new name in the run_imputation.py.